### PR TITLE
Setup.py was broken

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     platforms='any',
     install_requires=[
         'django',
-        'opentracing>=1.1<1.2'
+        'opentracing>=1.1,<1.2'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
``install_requires`` needs version constrains to have a `,` between conditions.