### PR TITLE
python3 fixes for tracer.py iteritems, Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lib
 *.egg-info
 build
 env/
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,11 @@ In order to implement tracing in your system, add the following lines of code to
 
     # if not included, defaults to False
     # has to come before OPENTRACING_TRACER setting because python...
-    OPENTRACING_TRACE_ALL = False, 
+    OPENTRACING_TRACE_ALL = False
 
     # defaults to []
     # only valid if OPENTRACING_TRACE_ALL == True
-    OPENTRACING_TRACED_ATTRIBUTES = ['arg1', 'arg2'],
+    OPENTRACING_TRACED_ATTRIBUTES = ['arg1', 'arg2']
 
     # Callable that returns an `opentracing.Tracer` implementation.
     OPENTRACING_TRACER_CALLABLE = 'opentracing.Tracer'
@@ -50,7 +50,7 @@ If you want to directly override the `DjangoTracer` used, you can use the follow
 .. code-block:: python
 
     # some_opentracing_tracer can be any valid OpenTracing tracer implementation
-    OPENTRACING_TRACER = django_opentracing.DjangoTracer(some_opentracing_tracer), 
+    OPENTRACING_TRACER = django_opentracing.DjangoTracer(some_opentracing_tracer)
 
 **Note:** Valid request attributes to trace are listed [here](https://docs.djangoproject.com/en/1.9/ref/request-response/#django.http.HttpRequest). When you trace an attribute, this means that created spans will have tags with the attribute name and the request's value.
 
@@ -101,6 +101,7 @@ Tracing an RPC
 If you want to make an RPC and continue an existing trace, you can inject the current span into the RPC. For example, if making an http request, the following code will continue your trace across the wire:
 
 .. code-block:: python
+    from future.utils import listitems # for python3 compatibility
 
     @tracer.trace()
     def some_view_func(request):
@@ -108,7 +109,7 @@ If you want to make an RPC and continue an existing trace, you can inject the cu
         current_span = tracer.get_span(request)
         text_carrier = {}
         opentracing_tracer.inject(span, opentracing.Format.TEXT_MAP, text_carrier)
-        for k, v in text_carrier.iteritems():
+        for k, v in listitems(text_carrier):
             request.add_header(k,v)
         ... # make request
 

--- a/django_opentracing/tracer.py
+++ b/django_opentracing/tracer.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.utils.module_loading import import_string
+from future.utils import listitems
 import opentracing
 import threading
 
@@ -64,7 +65,7 @@ class DjangoTracer(object):
         '''
         # strip headers for trace info
         headers = {}
-        for k,v in request.META.iteritems():
+        for k,v in listitems(request.META):
             k = k.lower().replace('_','-')
             if k.startswith('http-'):
                 k = k[5:]

--- a/example/client/views.py
+++ b/example/client/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import render
+from future.utils import listitems
 
 import opentracing
 import urllib2
@@ -51,6 +52,6 @@ def client_child_span(request):
 def inject_as_headers(tracer, span, request):
     text_carrier = {}
     tracer._tracer.inject(span.context, opentracing.Format.TEXT_MAP, text_carrier)
-    for k, v in text_carrier.iteritems():
+    for k, v in listitmes(text_carrier):
         request.add_header(k,v)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     platforms='any',
     install_requires=[
         'django',
-        'opentracing>=1.1,<1.2',
+        'opentracing>=1.1,<1.3',
         'future',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     platforms='any',
     install_requires=[
         'django',
-        'opentracing>=1.1,<1.2'
+        'opentracing>=1.1,<1.2',
+        'future',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
changing d.iteritems() to listitems(d) to allow python3 django apps

Running 2to3 on django_opentracing shows a few other possible fixes, mostly related to urllib2 but i don't yet have a python2 env to test so this PR is for the minimal changes required for me to get opentracing working (jaeger client).

Resolves https://github.com/opentracing-contrib/python-django/issues/15