### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/django_opentracing/tracer.py
+++ b/django_opentracing/tracer.py
@@ -64,7 +64,7 @@ class DjangoTracer(object):
         '''
         # strip headers for trace info
         headers = {}
-        for k,v in request.META.iteritems():
+        for k,v in request.META.items():
             k = k.lower().replace('_','-')
             if k.startswith('http-'):
                 k = k[5:]


### PR DESCRIPTION
* Fix AttributeError: 'dict' object has no attribute 'iteritems' in django_opentracing/tracer.py:71
* Fix issue #15 