### PR TITLE
Do not set opentracing.tracer.

### DIFF
--- a/django_opentracing/middleware.py
+++ b/django_opentracing/middleware.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django_opentracing.tracer import initialize_global_tracer
 try:
     # Django >= 1.10
     from django.utils.deprecation import MiddlewareMixin
@@ -19,7 +18,6 @@ class OpenTracingMiddleware(MiddlewareMixin):
         - Also, better to have try/catch with empty tracer or just fail fast if there's no tracer specified
         '''
         self.get_response = get_response
-        initialize_global_tracer()
         self._tracer = settings.OPENTRACING_TRACER
 
     def process_view(self, request, view_func, view_args, view_kwargs):


### PR DESCRIPTION
opentracing.tracer is supposed to be set directly
by the user, and consumed from everywhere else, not
the other way around (this is how it works under
Java and other languages instrumentation code).