### PR TITLE
Set the global tracer based on a parameter.

### DIFF
--- a/django_opentracing/tracer.py
+++ b/django_opentracing/tracer.py
@@ -106,6 +106,9 @@ def initialize_global_tracer():
 
     Here the global tracer object gets initialised once from Django settings.
     '''
+    if not getattr(settings, 'OPENTRACING_SET_GLOBAL_TRACER', False):
+        return
+
     # Short circuit without taking a lock
     if initialize_global_tracer.complete:
         return


### PR DESCRIPTION
This way, we won't break the contract with other instrumentation libraries, but we still provide this specific case if the user wants to go with it.