### PR TITLE
Relax opentracing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup
 import versioneer
 
-version=versioneer.get_version()
+version = versioneer.get_version()
 setup(
     name='django_opentracing',
     cmdclass=versioneer.get_cmdclass(),
     version=version,
     url='https://github.com/opentracing-contrib/python-django/',
-    download_url='https://github.com/opentracing-contrib/python-django/tarball/'+version,
+    download_url='https://github.com/opentracing-contrib/python-django/tarball/' + version,
     license='BSD',
     author='Kathy Camenzind',
     author_email='kcamenzind@lightstep.com',
@@ -17,7 +17,7 @@ setup(
     platforms='any',
     install_requires=[
         'django<2',
-        'opentracing>=1.1,<1.2',
+        'opentracing>=1.1,<2',
         'six',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup
 import versioneer
 
-version = versioneer.get_version()
+version=versioneer.get_version()
 setup(
     name='django_opentracing',
     cmdclass=versioneer.get_cmdclass(),
     version=version,
     url='https://github.com/opentracing-contrib/python-django/',
-    download_url='https://github.com/opentracing-contrib/python-django/tarball/' + version,
+    download_url='https://github.com/opentracing-contrib/python-django/tarball/'+version,
     license='BSD',
     author='Kathy Camenzind',
     author_email='kcamenzind@lightstep.com',


### PR DESCRIPTION
The most current package version cannot be used with jaeger_client_python due to conflict in opentracing dependency versions
Jaeger python client has requirement 
```
'opentracing>=1.2.2,<2'
```
(can be seen here https://github.com/jaegertracing/jaeger-client-python/blob/master/setup.py#L42)

while django_opentracing package has the following one
```
'opentracing>=1.1,<1.2',
```

I haven't found any specific code using `opentracing` dependency, which can be broken with a newer version. 