### PR TITLE
Fix link to Django docs in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,10 @@ If you want to directly override the ``DjangoTracing`` used, you can use the fol
     # some_opentracing_tracer can be any valid OpenTracing tracer implementation
     OPENTRACING_TRACING = django_opentracing.DjangoTracing(some_opentracing_tracer)
 
-**Note:** Valid request attributes to trace are listed [here](https://docs.djangoproject.com/en/1.9/ref/request-response/#django.http.HttpRequest). When you trace an attribute, this means that created spans will have tags with the attribute name and the request's value.
+**Note:** Valid request attributes to trace are listed  `here`_. When you trace an attribute, this means that created spans will have tags with the attribute name and the request's value.
+
+.. _here: https://docs.djangoproject.com/en/1.9/ref/request-response/#django.http.HttpRequest
+
 
 Tracing All Requests
 ====================

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ If you want to directly override the ``DjangoTracing`` used, you can use the fol
 
 **Note:** Valid request attributes to trace are listed  `here`_. When you trace an attribute, this means that created spans will have tags with the attribute name and the request's value.
 
-.. _here: https://docs.djangoproject.com/en/1.9/ref/request-response/#django.http.HttpRequest
+.. _here: https://docs.djangoproject.com/en/1.11/ref/request-response/#django.http.HttpRequest
 
 
 Tracing All Requests


### PR DESCRIPTION
It was using the markdown syntax for the link instead of the reStructuredText syntax.
It was also linking to a Django version that is no longer supported.
before:
<img width="1039" alt="Screenshot 2019-06-02 13 18 05" src="https://user-images.githubusercontent.com/1268088/58766890-2280b080-8539-11e9-9f2d-6a458df21079.png">

After:
<img width="958" alt="Screenshot 2019-06-02 13 20 34" src="https://user-images.githubusercontent.com/1268088/58766896-34faea00-8539-11e9-9c72-a587c42e16ff.png">
