### PR TITLE
Add another decorator to allow trace custom functions or methods that are not eclusivelly views.

### DIFF
--- a/django_opentracing/tracing.py
+++ b/django_opentracing/tracing.py
@@ -77,7 +77,7 @@ class DjangoTracing(object):
             def wrapper(*args, **kwargs):
                 # check if `func' is a method or not
                 if is_method:
-                    name = type(args[0])).__name__ + '.' + name
+                    name = type(args[0]).__name__ + '.' + name
                 with self.tracer.start_active_span(name):
                     return func(*args, **kwargs)
 

--- a/django_opentracing/tracing.py
+++ b/django_opentracing/tracing.py
@@ -72,6 +72,18 @@ class DjangoTracing(object):
             return wrapper
         return decorator
 
+    def another_trace(self, name, is_method=False):
+        def decorator(func):
+            def wrapper(*args, **kwargs):
+                # check if `func' is a method or not
+                if is_method:
+                    name = type(args[0])).__name__ + '.' + name
+                with self.tracer.start_active_span(name):
+                    return func(*args, **kwargs)
+
+            return wrapper
+        return decorator
+
     def _apply_tracing(self, request, view_func, attributes):
         '''
         Helper function to avoid rewriting for middleware and decorator.

--- a/django_opentracing/tracing.py
+++ b/django_opentracing/tracing.py
@@ -77,9 +77,13 @@ class DjangoTracing(object):
             def wrapper(*args, **kwargs):
                 # check if `func' is a method or not
                 if is_method:
-                    name = type(args[0]).__name__ + '.' + name
-                with self.tracer.start_active_span(name):
-                    return func(*args, **kwargs)
+                    fname = type(args[0]).__name__ + '.' + name
+                else:
+                    fname = name
+
+                with self.tracer.start_active_span(fname):
+                    r = func(*args, **kwargs)
+                    return r
 
             return wrapper
         return decorator


### PR DESCRIPTION
Using the `another_decorator()`, allows to crate a new span for custom functions or methods that are not views.